### PR TITLE
Update ORHelper for the new Core and Swing package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,7 @@ dmypy.json
 
 OpenRocket*.jar
 
+orhelper/bin/
+
 venv/
 .idea/

--- a/orhelper/_enums.py
+++ b/orhelper/_enums.py
@@ -15,7 +15,7 @@ class OrLogLevel(Enum):
     TRACE = auto()
     ALL = auto()
 
-# Mirrors net.sf.openrocket.simulation.FlightDataType
+# Mirrors info.openrocket.core.simulation.FlightDataType
 class FlightDataType(Enum):
     TYPE_TIME = auto()
     TYPE_ALTITUDE = auto()
@@ -73,7 +73,7 @@ class FlightDataType(Enum):
     TYPE_TIME_STEP = auto()
     TYPE_COMPUTATION_TIME = auto()
 
-# Mirrors net.sf.openrocket.simulation.FlightEvent
+# Mirrors info.openrocket.core.simulation.FlightEvent
 class FlightEvent(Enum):
     LAUNCH = auto()
     IGNITION = auto()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="orhelper",
-    version="0.1.3",
+    version="0.1.4",
     author="Andrei Popescu",
     author_email="Popescu.Andrei.David@gmail.com",
     description="OrHelper is a module which aims to facilitate interacting and scripting with OpenRocket from Python.",


### PR DESCRIPTION
This PR updates the references from the old `net.sf.openrocket` package to `info.openrocket.core` and `info.openrocket.swing`. So the plugin now works with the latest unstable version of OR.